### PR TITLE
Support multienv

### DIFF
--- a/commands/typescript/build.js
+++ b/commands/typescript/build.js
@@ -10,7 +10,10 @@ module.exports = {
         const { amplify, print } = context
        
         let projectDetails = await amplify.getProjectDetails();
-        let basePath = path.join(projectDetails.projectConfig.projectPath, 'amplify/backend/function');
+        const projectPath = projectDetails.projectConfig.projectPath 
+            ? projectDetails.projectConfig.projectPath
+            : projectDetails.localEnvInfo.projectPath;
+        let basePath = path.join(projectPath, 'amplify/backend/function');
         let functions = fs.readdirSync(basePath)
         
         for (const func of functions) {

--- a/commands/typescript/build.js
+++ b/commands/typescript/build.js
@@ -9,10 +9,7 @@ module.exports = {
     run: async (context) => {
         const { amplify, print } = context
        
-        let projectDetails = await amplify.getProjectDetails();
-        const projectPath = projectDetails.projectConfig.projectPath 
-            ? projectDetails.projectConfig.projectPath
-            : projectDetails.localEnvInfo.projectPath;
+        const projectPath = amplify.pathManager.searchProjectRootPath();
         let basePath = path.join(projectPath, 'amplify/backend/function');
         let functions = fs.readdirSync(basePath)
         


### PR DESCRIPTION
`projectDetails.projectConfig.projectPath` is undefined. Because amplify has supported multienv.
I changed to use searchProjectRootPath function of pathManager for retrieve project root path.